### PR TITLE
Add Weekly Shorts command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # **State Trackmania Bot discord.js**
 
-A simple trackmania bot used to fetch state trackmania records within state groups.
+This repository contains a small Discord bot built with **discord.js**. The bot interacts with the Trackmania.io API to display player stats and leaderboards right inside a Discord server. It exposes a set of slash commands that query campaigns, Track of the Day information and player profiles. All commands are located in the `commands/` folder and are automatically registered using `deploy-commands.js`.
+
+The bot keeps no persistent state; every command performs live requests against the Trackmania API. Authentication to the Trackmania services is handled in `functions/authentication.js`.
 
 ## Getting stated
 
@@ -55,4 +57,5 @@ node index.js
 | **currentrecords** | Get the top 5 records for a particular track in the current campaign                 | /currentrecords 15                          |
 | **playerprofile**  | Get a player's profile                                                               | /playerprofile Wirtual                      |
 | **records**        | Get records for a particular track in any campaign (this command does not work well) | /records campaign:summer 2020 tracknumber:1 |
-| **totdrecords**    | Get the top 5 records for the current campaign                                       | /totdrecords                                |
+| **totdrecords**    | Get the top 5 records for the Track of the Day                                       | /totdrecords                                |
+| **weeklyshorts**   | Get embeds for all Weekly Short maps with the top 5 players    | /weeklyshorts                               |

--- a/commands/weeklyshorts.js
+++ b/commands/weeklyshorts.js
@@ -1,0 +1,17 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const { getWeeklyShorts } = require('../functions/functions.js');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('weeklyshorts')
+        .setDescription('Get top 5 players for each Weekly Short map'),
+    async execute(interaction) {
+        await interaction.deferReply();
+        const results = await getWeeklyShorts();
+        if (!results.length) {
+            await interaction.editReply('Unable to fetch Weekly Shorts data.');
+            return;
+        }
+        await interaction.editReply({ embeds: results });
+    },
+};

--- a/functions/functions.js
+++ b/functions/functions.js
@@ -78,6 +78,29 @@ async function getTotdRecords(date) {
     return replyEmbed
 }
 
+async function getWeeklyShorts() {
+    const results = []
+    const search = await TMIOclient.campaigns.search('Weekly Shorts')
+    if (!search || !search.length) {
+        return results
+    }
+    const campaign = await search[0].getCampaign()
+    for (let i = 0; i < 5 && i < campaign._data.playlist.length; i++) {
+        const track = campaign._data.playlist[i]
+        const trackUid = track.mapUid
+        const trackName = track.name
+        const authorAccountId = track.author
+        let authorName = ''
+        await TMIOclient.players.get(authorAccountId).then(player => {
+            authorName = player.name
+        })
+        const topTimesResult = await getTopPlayerTimes(trackUid)
+        const embed = embedFormatter(trackName, trackUid, topTimesResult, authorName, authorAccountId)
+        results.push(embed)
+    }
+    return results
+}
+
 async function getTopPlayerScores(groupUId) {
     const APICredentials = await APILogin()
 
@@ -128,5 +151,8 @@ async function getTopPlayerScores(groupUId) {
 }
 
 module.exports = {
-    getCampaignRecords, getTotdRecords, getTopPlayerScores
+    getCampaignRecords,
+    getTotdRecords,
+    getTopPlayerScores,
+    getWeeklyShorts
 };


### PR DESCRIPTION
## Summary
- document repo overview and commands
- support a new `weeklyshorts` command
- fetch weekly shorts leaderboard data

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688011aec4488327b21b1533198abf23