### PR TITLE
Change default allowed command to weeklyshorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ ALLOWED_COMMANDS =
 - UBI_USERNAME: This is the email address used to login into Ubisoft.
 - UBI_PASSWORD: Password used to log into Ubisoft.
 - GROUP_UID: This is the group ID for your trackmania state or campaign group. To fetch this information, you might need to use the [Http inspector](https://openplanet.dev/plugin/httpinspect) plugin created by [Miss](https://github.com/sponsors/codecat) to inspect your incoming and outgoing packets to get your group ID.
-- ALLOWED_COMMANDS: Comma separated list of slash commands that the bot should register. Defaults to `totdrecords` if not set.
+- ALLOWED_COMMANDS: Comma separated list of slash commands that the bot should register. Defaults to `weeklyshorts` if not set.
 
 7. Run the following command to start running the project:
 

--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -10,7 +10,7 @@ const commandFiles = fs.readdirSync('./commands').filter(file => file.endsWith('
 
 const allowed = process.env.ALLOWED_COMMANDS
         ? process.env.ALLOWED_COMMANDS.split(',').map(c => c.trim())
-        : ['totdrecords'];
+        : ['weeklyshorts'];
 
 for (const file of commandFiles) {
         const command = require(`./commands/${file}`);

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const commandFiles = fs.readdirSync('./commands').filter((file) => file.endsWith
 
 const allowed = process.env.ALLOWED_COMMANDS
         ? process.env.ALLOWED_COMMANDS.split(',').map((c) => c.trim())
-        : ['totdrecords'];
+        : ['weeklyshorts'];
 
 for (const file of commandFiles) {
         const command = require(`./commands/${file}`);


### PR DESCRIPTION
## Summary
- switch the default command from `totdrecords` to `weeklyshorts`
- update README to document new default

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68801bec2f3083278b88e2742cc81ff8